### PR TITLE
Modify default path to use /etc/ssl/localcerts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,19 +2,19 @@
 # defaults file for roles/ssl-certificates
 
 # Server path to SSL public certificate
-ssl_certificate_public_path: /etc/ssl/server.crt
+ssl_certificate_public_path: /etc/ssl/localcerts/server.crt
 
 # Server path to SSL intermediate certificate(s)
-ssl_certificate_intermediate_path: /etc/ssl/intermediate.crt
+ssl_certificate_intermediate_path: /etc/ssl/localcerts/intermediate.crt
 
 # Server path to SSL bundled public and intermediate certificates
-ssl_certificate_bundled_path: /etc/ssl/bundled.crt
+ssl_certificate_bundled_path: /etc/ssl/localcerts/bundled.crt
 
 # Server path to SSL certificate key
-ssl_certificate_key_path: /etc/ssl/server.key
+ssl_certificate_key_path: /etc/ssl/localcerts/server.key
 
 # Server path to SSL combined certificate and key, set to empty to disable
-ssl_certificate_combined_path: /etc/ssl/combined.pem
+ssl_certificate_combined_path: /etc/ssl/localcerts/combined.pem
 
 # Text content of the public certificate
 ssl_certificate_public_content: ''

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -7,6 +7,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_certificate(Command, Sudo):
     with Sudo():
         out = Command.check_output(
-            'openssl x509 -in /etc/ssl/server.crt -noout -subject')
+            'openssl x509 -in /etc/ssl/localcerts/server.crt -noout -subject')
     assert out.startswith(
         'subject= /C=UK/ST=Scotland/L=Dundee/O=OME/CN=')

--- a/tests/test_intermediate.py
+++ b/tests/test_intermediate.py
@@ -12,7 +12,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_intermediate(Command, Sudo, cert):
     with Sudo():
         out = Command.check_output(
-            'openssl crl2pkcs7 -nocrl -certfile /etc/ssl/%s | '
+            'openssl crl2pkcs7 -nocrl -certfile /etc/ssl/localcerts/%s | '
             'openssl pkcs7 -print_certs -text -noout |grep Subject:'
             % cert)
         lines = out.splitlines()
@@ -28,7 +28,7 @@ def test_intermediate(Command, Sudo, cert):
 ])
 def test_combined(Command, Sudo, cert):
     with Sudo():
-        out = Command.check_output('grep BEGIN /etc/ssl/%s' % cert)
+        out = Command.check_output('grep BEGIN /etc/ssl/localcerts/%s' % cert)
     lines = out.splitlines()
     assert lines[0] == '-----BEGIN CERTIFICATE-----'
     assert lines[1] == '-----BEGIN CERTIFICATE-----'


### PR DESCRIPTION
See https://github.com/openmicroscopy/prod-playbooks/pull/51#discussion_r177001176

Updates the default paths of the role to use `/etc/ssl/localcerts`