### PR TITLE
Define a listener to trigger external restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,27 @@ Optional variables:
 - `ssl_certificate_selfsigned_days`: Self-signed certificate validity (days)
 
 
-Note this role does not configure or restart any webserver for SSL.
-This should be handled elsewhere.
+Listeners/Handlers
+------------------
+
+This role notifies a listener `ssl certificate changed` when any changes are made.
+This should be used to trigger a restart of any services dependent on the certificates.
 
 
 Example Playbooks
 -----------------
 
-Create a self-signed certificate with defaults:
+Create a self-signed certificate with defaults and restart Nginx (assumed to be already installed and configured):
 
     - hosts: all
       roles:
         - role: ssl-certificate
+      handlers:
+        - name: restart nginx
+          listen: ssl certificate changed
+          service:
+            name: nginx
+            state: restarted
 
 Install certificates stored locally on machine running Ansible:
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Handlers for ssl-certificate
+
+# Ensures there is always at least one listener to prevent Ansible errors
+- name: ssl certificate changed
+  debug:
+    msg: ssl certificate changed

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Manage SSL certificates for web-servers
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.3
   platforms:
   - name: EL
     versions:

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,3 +3,10 @@
 - hosts: all
   roles:
     - role: ansible-role-ssl-certificate
+
+  handlers:
+    - name: Create file when ssl certificate changed
+      listen: ssl certificate changed
+      # Use command so that we get an error if the handler is triggered during
+      # the idempotence check
+      command: touch /tmp/ssl-certificate-changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
     dest: "{{ ssl_certificate_public_path }}"
     mode: 0444
   when: 'ssl_certificate_public_content | length > 0'
+  notify: ssl certificate changed
 
 - name: ssl certificate | write SSL intermediate certificate
   become: yes
@@ -43,6 +44,7 @@
     dest: "{{ ssl_certificate_intermediate_path }}"
     mode: 0444
   when: 'ssl_certificate_intermediate_content | length > 0'
+  notify: ssl certificate changed
 
 - name: ssl certificate | write SSL certificate key
   become: yes
@@ -52,6 +54,7 @@
     mode: 0400
   no_log: True
   when: 'ssl_certificate_key_content | length > 0'
+  notify: ssl certificate changed
 
 # Self-signed
 # http://serialized.net/2013/04/simply-generating-self-signed-ssl-certs-with-ansible/
@@ -64,6 +67,7 @@
     # Don't overwrite existing certificate
     creates: "{{ ssl_certificate_key_path }}"
   when: ssl_certificate_selfsigned_create
+  notify: ssl certificate changed
 
 # Create combined certificate and key
 
@@ -89,6 +93,7 @@
     dest: "{{ ssl_certificate_bundled_path }}"
     mode: 0444
   when: "ssl_certificate_bundled_path | length > 0"
+  notify: ssl certificate changed
 
 - name: ssl certificate | write SSL combined certificate key
   become: yes
@@ -101,3 +106,4 @@
     mode: 0400
   no_log: True
   when: "ssl_certificate_combined_path | length > 0"
+  notify: ssl certificate changed

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -10,3 +10,7 @@ def test_certificate(Command, Sudo):
             'openssl x509 -in /etc/ssl/localcerts/server.crt -noout -subject')
     assert out.startswith(
         'subject= /C=UK/ST=Scotland/L=Dundee/O=OME/CN=')
+
+
+def test_listener_trigger(File):
+    assert File('/tmp/ssl-certificate-changed').exists


### PR DESCRIPTION
Defines a listener `ssl certificate changed`

Closes https://github.com/openmicroscopy/ansible-role-ssl-certificate/issues/2

Tag: `0.3.0` due to the bump in Ansible requirement, or we could go for `1.0.0`?