### PR TITLE
Add option to control OpenSSL installation in the role

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Optional variables:
 - `ssl_certificate_selfsigned_create`: Create a self-signed certificate if necessary, default `True`
 - `ssl_certificate_selfsigned_subject`: Self-signed certificate subject
 - `ssl_certificate_selfsigned_days`: Self-signed certificate validity (days)
-
+- `ssl_certificate_install_openssl`: Install OpenSSL, default `True`
 
 Listeners/Handlers
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,6 @@ ssl_certificate_selfsigned_subject: |-
 
 # Certificate validity (days)
 ssl_certificate_selfsigned_days: 365
+
+# Whether or not to install OpenSSL
+ssl_certificate_install_openssl: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
   package:
     name: openssl
     state: present
+  when: ssl_certificate_install_openssl
 
 - name: create certificates directory
   become: true


### PR DESCRIPTION
Under some conditions (upstream SSL expired), it can be useful to skip the installation of OpenSSL by the role in a deployment where the package is already installed.

This PR makes a backwards-compatible addition to make this step configurable but preserves the default behavior.

Proposed tag: `0.4.0` 